### PR TITLE
Issue #SB-4290 fix: No alert pop is displayed when any of the mandatory fields are not filled out

### DIFF
--- a/org.ekstep.metadata-1.1/editor/controller.js
+++ b/org.ekstep.metadata-1.1/editor/controller.js
@@ -63,6 +63,11 @@ angular.module('org.ekstep.metadataform', []).controller('metadataForm', ['$scop
     $scope.headerMessage = 'Edit Details'
 
     /**
+     * 
+     */
+    $scope.validationErrorMessage = 'Please provide all required details';
+
+    /**
      * @description          - Which is used to dispatch an event.
      * 
      * @param {String} event - Name of the event.
@@ -325,7 +330,7 @@ angular.module('org.ekstep.metadataform', []).controller('metadataForm', ['$scop
             }
         });
         ecEditor.dispatchEvent("org.ekstep.toaster:error", {
-            message: 'Please provide all required details.',
+            message: $scope.messages.validationError || $scope.validationErrorMessage,
             position: 'topCenter',
             icon: 'fa fa-warning'
         });
@@ -412,6 +417,7 @@ angular.module('org.ekstep.metadataform', []).controller('metadataForm', ['$scop
         !EventBus.hasEventListener('metadata:form:getdata') && ecEditor.addEventListener('metadata:form:getdata', $scope.getScopeMeta, $scope);
         var callbackFn = function(config) {
             $scope.fields = config.fields;
+            $scope.messages = config.messages;
             $scope.tempalteName = config.template;
             if (_.isUndefined(config.editMode)) {
                 config.editMode = true

--- a/org.ekstep.metadata-1.1/editor/controller.js
+++ b/org.ekstep.metadata-1.1/editor/controller.js
@@ -417,7 +417,7 @@ angular.module('org.ekstep.metadataform', []).controller('metadataForm', ['$scop
         !EventBus.hasEventListener('metadata:form:getdata') && ecEditor.addEventListener('metadata:form:getdata', $scope.getScopeMeta, $scope);
         var callbackFn = function(config) {
             $scope.fields = config.fields;
-            $scope.messages = config.messages;
+            $scope.messages = config.messages || {};
             $scope.tempalteName = config.template;
             if (_.isUndefined(config.editMode)) {
                 config.editMode = true

--- a/org.ekstep.metadata-1.1/editor/controller.js
+++ b/org.ekstep.metadata-1.1/editor/controller.js
@@ -324,6 +324,11 @@ angular.module('org.ekstep.metadataform', []).controller('metadataForm', ['$scop
                 }
             }
         });
+        ecEditor.dispatchEvent("org.ekstep.toaster:error", {
+            message: 'Please provide all required details.',
+            position: 'topCenter',
+            icon: 'fa fa-warning'
+        });
     }
 
     /** 

--- a/org.ekstep.sunbirdmetadata-1.1/editor/plugin.js
+++ b/org.ekstep.sunbirdmetadata-1.1/editor/plugin.js
@@ -322,7 +322,7 @@ org.ekstep.contenteditor.metadataPlugin.extend({
     },
 
     returnConfigs: function(event, callbackFn) {
-        callbackFn({ model: this.getModel(), template: this.config.templateName || this.DEFAULT_TEMPLATE_NAME, fields: this.form, editMode: this.editMode })
+        callbackFn({ model: this.getModel(), template: this.config.templateName || this.DEFAULT_TEMPLATE_NAME, fields: this.form, editMode: this.editMode, messages: this.config.messages })
     }
 })
 


### PR DESCRIPTION
Issue #SB-4290 fix: No alert pop is displayed when any of the mandatory fields are not filled out. Proper alert message would help