### PR TITLE
Issue #1263 fix: dialcode success message is displaying though the dialcode field is empty

### DIFF
--- a/org.ekstep.metadata-1.1/editor/directives/dialCode/dialCodeDirective.js
+++ b/org.ekstep.metadata-1.1/editor/directives/dialCode/dialCodeDirective.js
@@ -9,11 +9,13 @@ angular.module('editorApp', ['ngDialog', 'oc.lazyLoad', 'Scope.safeApply']).dire
     var dialCodeController = ['$scope', '$controller', '$filter', function($scope, $controller, $filter) {
         $scope.mode = ecEditor.getConfig('editorConfig').mode;
         $scope.contentMeta = ecEditor.getService('content').getContentMeta(org.ekstep.contenteditor.api.getContext('contentId'));
-        $scope.maxLength = 6;
-        $scope.minLength = 0;
+        $scope.maxChar = 6;
+        $scope.minChar = 0;
         $scope.editFlag = false;
         $scope.errorMessage = "";
-        $scope.status = "";
+        $scope.status = true;
+
+    var stateService = org.ekstep.services.stateService;  
 
         $scope.searchDialCode = function(dialcode, callback){
             var channel = ecEditor.getContext('channel');
@@ -24,13 +26,16 @@ angular.module('editorApp', ['ngDialog', 'oc.lazyLoad', 'Scope.safeApply']).dire
                     }
                 }
             };
-            ecEditor.getService('dialcode').getAllDialCodes(channel, reqObj, function(dialerr, dialrep) {
-                if (!dialerr) {
-                    if (dialrep.data.result.count === 1)
-                        ecEditor._.uniq(org.ekstep.services.collectionService.dialcodeList.push(dialrep.data.result.dialcodes[0].identifier));
-                    callback && callback(dialrep.data.result.count);
+            ecEditor.getService('dialcode').getAllDialCodes(channel, reqObj, function(err, res) {
+                if (!err) {
+                    if (res.data.result.count){
+                        ecEditor._.uniq(org.ekstep.services.collectionService.dialcodeList.push(res.data.result.dialcodes[0].identifier));
+                        callback && callback({ isValid:true, dialcode:res.data.result.dialcodes });
+                    } else{
+                        callback && callback({ isValid:false, dialcode:undefined });
+                    }
                 }else{
-                    console.log('unable to find dialcodes!', dialrep);
+                    console.error('Invalid DIAL Code!', err);
                 }
             });
         }
@@ -45,37 +50,37 @@ angular.module('editorApp', ['ngDialog', 'oc.lazyLoad', 'Scope.safeApply']).dire
                     org.ekstep.collectioneditor.cache.nodesModified[node.data.id].metadata["dialcodes"] = this.dialcodes;
                 }
                 if (ecEditor._.indexOf(org.ekstep.services.collectionService.dialcodeList, this.dialcodes) != -1) {
-                    $scope.status = "success";
+                    $scope.status = true;
+                    _.has(stateService.state.invaliddialCodeMap, node.data.id) ? _.unset(stateService.state.invaliddialCodeMap, node.data.id) : "";
                     if ($scope.contentMeta.mimeType == 'application/vnd.ekstep.content-collection') {
-                        if (!org.ekstep.services.stateService.state.dialCodeMap) {
-                            org.ekstep.services.stateService.create('dialCodeMap');
+                        if (!stateService.state.dialCodeMap) {
+                            stateService.create('dialCodeMap');
                         }
-                        org.ekstep.services.stateService.setState('dialCodeMap', node.data.id, this.dialcodes);
-                    }
-                    if (org.ekstep.services.stateService.state.invaliddialCodeMap) {
-                        _.unset(org.ekstep.services.stateService.state.invaliddialCodeMap, node.data.id)
+                        stateService.setState('dialCodeMap', node.data.id, this.dialcodes);
                     }
                     $scope.editFlag = true;
                     ecEditor.dispatchEvent('org.ekstep.collectioneditor:node:modified');
                 }else{
                     $scope.searchDialCode(this.dialcodes, function(response){
-                        if(response === 1){
-                            $scope.status = "success";
+                        if(response.isValid){
+                            $scope.status = response.isValid;
+                            _.has(stateService.state.invaliddialCodeMap, node.data.id) ? _.unset(stateService.state.invaliddialCodeMap, node.data.id) : "";
                             if ($scope.contentMeta.mimeType == 'application/vnd.ekstep.content-collection') {
-                                if (!org.ekstep.services.stateService.state.dialCodeMap) {
-                                    org.ekstep.services.stateService.create('dialCodeMap');
+                                if (!stateService.state.dialCodeMap) {
+                                    stateService.create('dialCodeMap');
                                 }
-                                org.ekstep.services.stateService.setState('dialCodeMap', node.data.id, instance.dialcodes);
+                                stateService.setState('dialCodeMap', node.data.id, instance.dialcodes);
                             }
                             $scope.editFlag = true;
                             ecEditor.dispatchEvent('org.ekstep.collectioneditor:node:modified');
                             $scope.$safeApply();
                         }else{
-                            if (!org.ekstep.services.stateService.state.invaliddialCodeMap) {
-                                org.ekstep.services.stateService.create('invaliddialCodeMap');
+                            if (!stateService.state.invaliddialCodeMap) {
+                                stateService.create('invaliddialCodeMap');
                             }
-                            org.ekstep.services.stateService.setState('invaliddialCodeMap', node.data.id, instance.dialcodes);
-                            $scope.status = "failure";
+                            _.has(stateService.state.dialCodeMap, node.data.id) ? _.unset(stateService.state.dialCodeMap, node.data.id) : "";
+                            stateService.setState('invaliddialCodeMap', node.data.id, instance.dialcodes);
+                            $scope.status = response.isValid;
                             $scope.editFlag = true;
                             ecEditor.dispatchEvent('org.ekstep.collectioneditor:node:modified');
                             $scope.$safeApply();
@@ -100,35 +105,35 @@ angular.module('editorApp', ['ngDialog', 'oc.lazyLoad', 'Scope.safeApply']).dire
             if (org.ekstep.collectioneditor.cache.nodesModified && org.ekstep.collectioneditor.cache.nodesModified[nodeId]) {
                 org.ekstep.collectioneditor.cache.nodesModified[nodeId].metadata["dialcodes"] = [];
             }
-            if (!org.ekstep.services.stateService.state.dialCodeMap) {
-                org.ekstep.services.stateService.create('dialCodeMap');
+            if (!stateService.state.dialCodeMap) {
+                stateService.create('dialCodeMap');
             }
-            org.ekstep.services.stateService.setState('dialCodeMap', nodeId, "");
-            if (org.ekstep.services.stateService.state.invaliddialCodeMap) {
-                _.unset(org.ekstep.services.stateService.state.invaliddialCodeMap, nodeId)
-            }
+            _.has(stateService.state.invaliddialCodeMap, nodeId) ? _.unset(stateService.state.invaliddialCodeMap, nodeId) : "";
+            stateService.setState('dialCodeMap', nodeId, "");
             ecEditor.dispatchEvent('org.ekstep.collectioneditor:node:modified');
         }
 
         $scope.changeDialCode = function () {
-            $scope.errorMessage = "";
-            if(_.isEmpty(this.dialcodes)){
-                var nodeId = ecEditor.jQuery("#collection-tree").fancytree("getRootNode").getFirstChild().data.id;
-                if (org.ekstep.collectioneditor.cache.nodesModified && org.ekstep.collectioneditor.cache.nodesModified[nodeId]) {
-                    org.ekstep.collectioneditor.cache.nodesModified[nodeId].metadata["dialcodes"] = [];
-                }
-                if (!org.ekstep.services.stateService.state.dialCodeMap) {
-                    org.ekstep.services.stateService.create('dialCodeMap');
-                }
-                org.ekstep.services.stateService.setState('dialCodeMap', nodeId, "");
-                if (org.ekstep.services.stateService.state.invaliddialCodeMap) {
-                    _.unset(org.ekstep.services.stateService.state.invaliddialCodeMap, nodeId)
-                }
-                ecEditor.dispatchEvent('org.ekstep.collectioneditor:node:modified');
-            }else if (!String(this.dialcodes).match(/^[A-Z0-9]{6}$/) || this.dialcodes.length < 6) {
+            var currentNode = ecEditor.jQuery("#collection-tree").fancytree("getRootNode").getFirstChild().data;
+            if(_.isEmpty(this.dialcodes)) {
+                $scope.errorMessage = "";
                 $scope.editFlag = false;
-                $scope.errorMessage = "Please enter valid DIAL code";
-            }
+                _.has(stateService.state.invaliddialCodeMap, currentNode.id) ? _.unset(stateService.state.invaliddialCodeMap, currentNode.id) : "";
+                _.has(stateService.state.dialCodeMap, currentNode.id) ? _.unset(stateService.state.dialCodeMap, currentNode.id) : "";
+                if(currentNode.metadata && currentNode.metadata.dialcodes && currentNode.metadata.dialcodes.length){
+                    if (org.ekstep.collectioneditor.cache.nodesModified && org.ekstep.collectioneditor.cache.nodesModified[currentNode.id]) {
+                        org.ekstep.collectioneditor.cache.nodesModified[currentNode.id].metadata["dialcodes"] = [];
+                    }
+                    if (!stateService.state.dialCodeMap) {
+                        stateService.create('dialCodeMap');
+                    }
+                    stateService.setState('dialCodeMap', currentNode.id, "");
+                    ecEditor.dispatchEvent('org.ekstep.collectioneditor:node:modified');
+                }
+            } else {
+                $scope.editFlag = false;
+                $scope.errorMessage = (this.dialcodes.length && !String(this.dialcodes).match(/^[A-Z0-9]{6}$/)) ? "Please enter valid DIAL code" : "";
+            }    
         }
 
         $scope.init = function () {
@@ -152,12 +157,12 @@ angular.module('editorApp', ['ngDialog', 'oc.lazyLoad', 'Scope.safeApply']).dire
                 if(_.isArray($scope.dialcodes)){
                     $scope.dialcodes = $scope.dialcodes[0];
                 }
-                $scope.editFlag = ($scope.dialcodes && ($scope.dialcodes.length == $scope.maxLength)) ? true : false;
+                $scope.editFlag = ($scope.dialcodes && ($scope.dialcodes.length == $scope.maxChar)) ? true : false;
                 if (ecEditor._.indexOf(org.ekstep.services.collectionService.dialcodeList, $scope.dialcodes) != -1) {
-                    $scope.status = "success";
+                    $scope.status = true;
                 }else{
                     $scope.searchDialCode($scope.dialcodes, function(response){
-                        $scope.status = (response === 1) ? "success"  : "failure"
+                        $scope.status = response.isValid;
                         $scope.$safeApply();
                     });
                 }

--- a/org.ekstep.metadata-1.1/editor/directives/dialCode/template.html
+++ b/org.ekstep.metadata-1.1/editor/directives/dialCode/template.html
@@ -1,25 +1,25 @@
 <div class="field">
-    <label style="align-items: center;display: flex">Dial code
+    <label>Dial code
         <span class="ui icon" data-tooltip="Digital Infrastructure for Augmented Learning" data-position="top left">
             <i style="cursor: pointer;color: #007aff;" class="large question circle icon link"></i>
         </span>
-    <a ng-show="editFlag && mode == 'Edit'" ng-click="editDialCode()" style="cursor:pointer;color: #007aff !important;">Edit</a>
-    <span ng-show="!editFlag" style="background-color: transparent;text-align: right;width: 19vw">{{dialcodes.length || minLength}}/{{maxLength}}</span>
+        <a ng-show="editFlag && mode == 'Edit'" ng-click="editDialCode()" style="cursor:pointer;color: #007aff !important;">Edit</a>
+        <span ng-show="!editFlag" style="float: right">{{dialcodes.length || minChar}}/{{ maxChar }}</span>
     </label>
     <div class="ui action right icon input" ng-class="mode == 'Edit' ? '' : 'disabled'" style="align-items: center;">
         <input ng-show="!editFlag" class="dialCode" type="text" placeholder="Enter code here" ng-model="dialcodes" maxlength="6" ng-disabled="false" ng-change="changeDialCode()">
         <div ng-show="editFlag" class="ui action right icon input">
             <div class="ui action right icon">
                 {{dialcodes}}
-                <i ng-show="status == 'success'" style="font-size:17px" class="small green check icon"></i>
-                <i ng-show="status == 'failure'" style="font-size:17px" class="small red remove icon"></i><span style="color: #d61011;" ng-show="status == 'failure'">Invalid DIAL code</span>
+                <i ng-show="status" style="font-size:17px" class="small green check icon"></i>
+                <i ng-show="!status" style="font-size:17px" class="small red remove icon"></i><span style="color: #d61011;" ng-show="!status">Invalid DIAL code</span>
             </div>
         </div>
-        <div ng-show="dialcodes.length == maxLength && !editFlag" ng-click="clearDialCode()" style="cursor:pointer">
+        <div ng-show="dialcodes.length == maxChar && !editFlag" ng-click="clearDialCode()" style="cursor:pointer">
             <i class="large red remove circle icon"></i>
         </div>
-        <div ng-show="dialcodes.length == maxLength && !editFlag" ng-click="validateDialCode()" style="cursor:pointer">
-            <i class="large check circle icon" style="color: #007aff;"></i>
+        <div ng-show="dialcodes.length == maxChar && !editFlag" ng-click="validateDialCode()" style="cursor:pointer">
+            <i class="large check circle icon" style="color: #007aff"></i>
         </div>
     </div>
     <div class="ui pointing red basic label" ng-show="errorMessage">

--- a/org.ekstep.unitmeta-1.5/editor/directives/dialCode/dialCodeDirective.js
+++ b/org.ekstep.unitmeta-1.5/editor/directives/dialCode/dialCodeDirective.js
@@ -14,6 +14,8 @@ angular.module('editorApp', ['ngDialog', 'oc.lazyLoad', 'Scope.safeApply']).dire
         $scope.errorMessage = "";
         $scope.status = true;
 
+    var stateService = org.ekstep.services.stateService;  
+
         $scope.searchDialCode = function(dialcode, callback){
             var channel = ecEditor.getContext('channel');
             var reqObj = {
@@ -48,14 +50,12 @@ angular.module('editorApp', ['ngDialog', 'oc.lazyLoad', 'Scope.safeApply']).dire
                 }
                 if (ecEditor._.indexOf(org.ekstep.services.collectionService.dialcodeList, this.dialcodes) != -1 ) {
                     $scope.status = true;
+                    _.has(stateService.state.invaliddialCodeMap, node.data.id) ? _.unset(stateService.state.invaliddialCodeMap, node.data.id) : "";
                     if ($scope.contentMeta.mimeType == 'application/vnd.ekstep.content-collection') {
-                        if (!org.ekstep.services.stateService.state.dialCodeMap) {
-                            org.ekstep.services.stateService.create('dialCodeMap');
+                        if (!stateService.state.dialCodeMap) {
+                            stateService.create('dialCodeMap');
                         }
-                        org.ekstep.services.stateService.setState('dialCodeMap', node.data.id, this.dialcodes);
-                    }
-                    if (org.ekstep.services.stateService.state.invaliddialCodeMap) {
-                        _.unset(org.ekstep.services.stateService.state.invaliddialCodeMap, node.data.id)
+                        stateService.setState('dialCodeMap', node.data.id, this.dialcodes);
                     }
                     $scope.editFlag = true;
                     ecEditor.dispatchEvent('org.ekstep.collectioneditor:node:modified');
@@ -63,23 +63,22 @@ angular.module('editorApp', ['ngDialog', 'oc.lazyLoad', 'Scope.safeApply']).dire
                     $scope.searchDialCode(this.dialcodes, function(response){
                         if(response.isValid){
                             $scope.status = response.isValid;
+                            _.has(stateService.state.invaliddialCodeMap, node.data.id) ? _.unset(stateService.state.invaliddialCodeMap, node.data.id) : "";
                             if ($scope.contentMeta.mimeType == 'application/vnd.ekstep.content-collection') {
-                                if (!org.ekstep.services.stateService.state.dialCodeMap) {
-                                    org.ekstep.services.stateService.create('dialCodeMap');
+                                if (!stateService.state.dialCodeMap) {
+                                    stateService.create('dialCodeMap');
                                 }
-                                org.ekstep.services.stateService.setState('dialCodeMap', node.data.id, instance.dialcodes);
-                            }
-                            if (org.ekstep.services.stateService.state.invaliddialCodeMap) {
-                                _.unset(org.ekstep.services.stateService.state.invaliddialCodeMap, node.data.id)
+                                stateService.setState('dialCodeMap', node.data.id, instance.dialcodes);
                             }
                             $scope.editFlag = true;
                             ecEditor.dispatchEvent('org.ekstep.collectioneditor:node:modified');
                             $scope.$safeApply();
                         }else{
-                            if (!org.ekstep.services.stateService.state.invaliddialCodeMap) {
-                                org.ekstep.services.stateService.create('invaliddialCodeMap');
+                            if (!stateService.state.invaliddialCodeMap) {
+                                stateService.create('invaliddialCodeMap');
                             }
-                            org.ekstep.services.stateService.setState('invaliddialCodeMap', node.data.id, instance.dialcodes);
+                            _.has(stateService.state.dialCodeMap, node.data.id) ? _.unset(stateService.state.dialCodeMap, node.data.id) : "";
+                            stateService.setState('invaliddialCodeMap', node.data.id, instance.dialcodes);
                             $scope.status = response.isValid;
                             $scope.editFlag = true;
                             ecEditor.dispatchEvent('org.ekstep.collectioneditor:node:modified');
@@ -105,35 +104,35 @@ angular.module('editorApp', ['ngDialog', 'oc.lazyLoad', 'Scope.safeApply']).dire
             if (org.ekstep.collectioneditor.cache.nodesModified && org.ekstep.collectioneditor.cache.nodesModified[nodeId]) {
                 org.ekstep.collectioneditor.cache.nodesModified[nodeId].metadata["dialcodes"] = [];
             }
-            if (!org.ekstep.services.stateService.state.dialCodeMap) {
-                org.ekstep.services.stateService.create('dialCodeMap');
+            if (!stateService.state.dialCodeMap) {
+                stateService.create('dialCodeMap');
             }
-            org.ekstep.services.stateService.setState('dialCodeMap', nodeId, "");
-            if (org.ekstep.services.stateService.state.invaliddialCodeMap) {
-                _.unset(org.ekstep.services.stateService.state.invaliddialCodeMap, nodeId)
-            }
+            _.has(stateService.state.invaliddialCodeMap, nodeId) ? _.unset(stateService.state.invaliddialCodeMap, nodeId) : "";
+            stateService.setState('dialCodeMap', nodeId, "");
             ecEditor.dispatchEvent('org.ekstep.collectioneditor:node:modified');
         }
 
         $scope.changeDialCode = function () {
-            $scope.errorMessage = "";
-            if(_.isEmpty(this.dialcodes)){
-                var nodeId = org.ekstep.services.collectionService.getActiveNode().data.id;
-                if (org.ekstep.collectioneditor.cache.nodesModified && org.ekstep.collectioneditor.cache.nodesModified[nodeId]) {
-                    org.ekstep.collectioneditor.cache.nodesModified[nodeId].metadata["dialcodes"] = [];
-                }
-                if (!org.ekstep.services.stateService.state.dialCodeMap) {
-                    org.ekstep.services.stateService.create('dialCodeMap');
-                }
-                org.ekstep.services.stateService.setState('dialCodeMap', nodeId, "");
-                if (org.ekstep.services.stateService.state.invaliddialCodeMap) {
-                    _.unset(org.ekstep.services.stateService.state.invaliddialCodeMap, nodeId)
-                }
-                ecEditor.dispatchEvent('org.ekstep.collectioneditor:node:modified');
-            }else if (!String(this.dialcodes).match(/^[A-Z0-9]{6}$/) || this.dialcodes.length < 6) {
+            var currentNode = org.ekstep.services.collectionService.getActiveNode().data;
+            if(_.isEmpty(this.dialcodes)) {
+                $scope.errorMessage = "";
                 $scope.editFlag = false;
-                $scope.errorMessage = "Please enter valid DIAL code";
-            }
+                _.has(stateService.state.invaliddialCodeMap, currentNode.id) ? _.unset(stateService.state.invaliddialCodeMap, currentNode.id) : "";
+                _.has(stateService.state.dialCodeMap, currentNode.id) ? _.unset(stateService.state.dialCodeMap, currentNode.id) : "";
+                if(currentNode.metadata && currentNode.metadata.dialcodes && currentNode.metadata.dialcodes.length){
+                    if (org.ekstep.collectioneditor.cache.nodesModified && org.ekstep.collectioneditor.cache.nodesModified[currentNode.id]) {
+                        org.ekstep.collectioneditor.cache.nodesModified[currentNode.id].metadata["dialcodes"] = [];
+                    }
+                    if (!stateService.state.dialCodeMap) {
+                        stateService.create('dialCodeMap');
+                    }
+                    stateService.setState('dialCodeMap', currentNode.id, "");
+                    ecEditor.dispatchEvent('org.ekstep.collectioneditor:node:modified');
+                }
+            } else {
+                $scope.editFlag = false;
+                $scope.errorMessage = (this.dialcodes.length && !String(this.dialcodes).match(/^[A-Z0-9]{6}$/)) ? "Please enter valid DIAL code" : "";
+            }    
         }
 
         $scope.init = function () {


### PR DESCRIPTION
Description:
Dial-code success message is displaying though the field is empty.
Scenarios:
ekstep/CE-Core-Plugins#1263
ekstep/Collection-Editor#104