### PR TITLE
Dialcode update message displaying wrong when dial code is empty.

### DIFF
--- a/org.ekstep.contenteditorfunctions-1.2/editor/plugin.js
+++ b/org.ekstep.contenteditorfunctions-1.2/editor/plugin.js
@@ -495,7 +495,8 @@ org.ekstep.contenteditor.basePlugin.extend({
         instance.dialcodeLink(mapArr);
     },
     dialcodeLink: function(dialcodeMap) {
-        if(!_.isEmpty(dialcodeMap)){
+        dialcodeMapObj = _.find(dialcodeMap, 'dialcode');
+        if(dialcodeMapObj && dialcodeMapObj.dialcode){
             var request = {
                 "request": {
                     "content": dialcodeMap

--- a/org.ekstep.contenteditorfunctions-1.2/editor/plugin.js
+++ b/org.ekstep.contenteditorfunctions-1.2/editor/plugin.js
@@ -495,8 +495,8 @@ org.ekstep.contenteditor.basePlugin.extend({
         instance.dialcodeLink(mapArr);
     },
     dialcodeLink: function(dialcodeMap) {
-        dialcodeMapObj = _.find(dialcodeMap, 'dialcode');
-        if(dialcodeMapObj && dialcodeMapObj.dialcode){
+        var dialcodeMapObj = _.find(dialcodeMap, 'dialcode');
+        if(!_.isEmpty(dialcodeMap)){
             var request = {
                 "request": {
                     "content": dialcodeMap
@@ -510,7 +510,7 @@ org.ekstep.contenteditor.basePlugin.extend({
                             position: 'topCenter',
                             icon: 'fa fa-warning'
                         });
-                    }else{
+                    }else if(dialcodeMapObj && dialcodeMapObj.dialcode){
                         ecEditor.dispatchEvent("org.ekstep.toaster:success", {
                             title: 'DIAL code(s) updated successfully!',
                             position: 'topCenter',


### PR DESCRIPTION
**Description:**
Dial code update successfully message is displaying when there is no dial code in dial code field on Edit details page

**Test Cases and Scenarios:**
https://project-sunbird.atlassian.net/browse/SB-4552
