### PR TITLE
Issue #SB-6241 fix: Test cases - Dynamic filters for resource browser

### DIFF
--- a/org.ekstep.lessonbrowser-1.4/editor/plugin.js
+++ b/org.ekstep.lessonbrowser-1.4/editor/plugin.js
@@ -22,14 +22,7 @@ org.ekstep.collectioneditor.basePlugin.extend({
         var templatePath = org.ekstep.contenteditor.api.resolvePluginResource(this.manifest.id, this.manifest.ver, "editor/lessonBrowser.html");
         var controllerPath = org.ekstep.contenteditor.api.resolvePluginResource(this.manifest.id, this.manifest.ver, "editor/lessonBrowserApp.js");
         org.ekstep.contenteditor.api.getService('popup').loadNgModules(templatePath, controllerPath);
-        ecEditor.addEventListener('editor:invoke:viewall', this.initPreview, this)
-       // this.registerRepo(this.getEkstepRepo());
-    },
-
-    registerRepo: function(repo) {
-        var instance = this;
-        org.ekstep.contenteditor.api.getService('popup').loadNgModules(repo.templateUrl, repo.controllerUrl);
-        instance.repos.push(repo);
+        ecEditor.addEventListener('editor:invoke:viewall', this.initPreview, this);
     },
 
     /**
@@ -66,25 +59,5 @@ org.ekstep.collectioneditor.basePlugin.extend({
             className: 'ngdialog-theme-plain lessonbrowser-dialog'
         });
     },
-
-    getEkstepRepo: function() {
-        var instance = this;
-        var repo = new(org.ekstep.collectioneditor.contentProviderRepo.extend({
-            id: 'ekstep',
-            label: 'EkStep',
-            templateUrl: undefined,
-            controllerUrl: undefined,
-
-            init: function() {
-                this.templateUrl = org.ekstep.contenteditor.api.resolvePluginResource(instance.manifest.id, instance.manifest.ver, "editor/repoEkstep.html");
-                this.controllerUrl = org.ekstep.contenteditor.api.resolvePluginResource(instance.manifest.id, instance.manifest.ver, "editor/repoEkstepApp.js");
-            },
-            getFilters: function() {
-                return { "language": [], "grade": [], "lessonType": [], "domain": [] };
-            }
-        }));
-
-        return repo;
-    }
 });
 //# sourceURL=lessonbrowserplugin.js

--- a/org.ekstep.lessonbrowser-1.4/test/editor/plugin.spec.js
+++ b/org.ekstep.lessonbrowser-1.4/test/editor/plugin.spec.js
@@ -1,13 +1,10 @@
 describe("lesson browser plugin", function() {
     var manifest, path, ctrl, $scope, pluginInstance;
     beforeAll(function(done) {
-        CollectionEditorTestFramework.init(function() {
+       org.ekstep.pluginframework.pluginManager.loadPlugin('org.ekstep.lessonbrowser', '1.4', function() {
             manifest = org.ekstep.pluginframework.pluginManager.getPluginManifest("org.ekstep.lessonbrowser");
             path = ecEditor.resolvePluginResource(manifest.id, manifest.ver, "editor/lessonBrowserApp.js");
-            pluginInstance = ecEditor.instantiatePlugin("org.ekstep.lessonbrowser");
-            var templatePath = ecEditor.resolvePluginResource(manifest.id, manifest.ver, "editor/lessonbrowser.html");
-            var controllerPath = ecEditor.resolvePluginResource(manifest.id, manifest.ver, "editor/lessonBrowserApp.js");
-            ecEditor.getService(ServiceConstants.POPUP_SERVICE).loadNgModules(templatePath, controllerPath);
+            pluginInstance = org.ekstep.pluginframework.pluginManager.pluginObjs["org.ekstep.lessonbrowser"];
             done();
         });
     });
@@ -34,56 +31,111 @@ describe("lesson browser plugin", function() {
     });
     
     describe("Lesson browser", function() {
-    	it("It should initialized Lesson browser plugin", function() {
-            spyOn(pluginInstance, 'initialize').and.callThrough();
-            pluginInstance.initialize(manifest);
-            console.log("manifest", manifest);
-            console.log("pluginInstance", pluginInstance);
-            expect(pluginInstance.initialize).toHaveBeenCalled();
-        });
-        it("Should initialize the lesson browser without filters", function(done) {
-            spyOn($scope, "initPreview").and.callThrough();
-            ecEditor.dispatchEvent('org.ekstep.lessonbrowser:show', {
-                "filters": {
-                    "lessonType": [
-                    "Resource"
-                    ]
-                }
+        describe("Init lesson browser", function() {
+            it("It should initialized Lesson browser plugin", function() {
+                spyOn(pluginInstance, 'initialize').and.callThrough();
+                pluginInstance.initialize(manifest);
+                expect(pluginInstance.initialize).toHaveBeenCalled();
             });
-            expect($scope.mainTemplate).toEqual("cardDetailsView");
-            done();
-        });
-        it("Should initialize the lesson browser with filters", function(done) {
-            spyOn($scope, "initPreview").and.callThrough();
-            ecEditor.dispatchEvent('editor:invoke:viewall', {
-                "client": "org",
-                "request": {
-                    "mode": "soft",
-                    "filters": {
-                    "objectType": [
-                        "Content"
-                    ],
-                    "status": [
-                        "Live"
-                    ],
-                    "contentType": [
-                        "Collection",
-                        "Resource",
-                        "Story",
-                        "Worksheet"
-                    ]
-                    },
-                    "offset": 0,
-                    "limit": 100,
-                    "softConstraints": {
-                    "gradeLevel": 100,
-                    "medium": 50,
-                    "board": 25
+            it("Should initialize the lesson browser with filters", function(done) {
+                spyOn(pluginInstance, "initPreview").and.callThrough();
+                var query = {
+                    "query": {
+                        "lessonType": [
+                        "Resource"
+                        ]
                     }
-                },"callback": callback()
+                };
+                ecEditor.dispatchEvent('org.ekstep.lessonbrowser:show', query);
+                expect(pluginInstance.query).toEqual(query.query);
+                done();
             });
-            expect($scope.mainTemplate).toEqual("selectedResult");
-            done();
+            it("By dispatching editor:invoke:viewall event init preview should called", function(done) {
+                spyOn(pluginInstance, "initPreview").and.callThrough();
+                ecEditor.dispatchEvent('editor:invoke:viewall', {
+                    "client": "org",
+                    "request": {
+                        "mode": "soft",
+                        "filters": {
+                        "objectType": [
+                            "Content"
+                        ],
+                        "status": [
+                            "Live"
+                        ],
+                        "contentType": [
+                            "Collection",
+                            "Resource"
+                        ]
+                        },
+                        "offset": 0,
+                        "limit": 100,
+                        "softConstraints": {
+                        "gradeLevel": 100,
+                        "medium": 50,
+                        "board": 25
+                        }
+                    },"callback": function(){}
+                });
+                expect(pluginInstance.client).toEqual("org");
+                done();
+            });
+        });
+        describe("View all", function() {
+            it("ContentType filter should prefilled with Resource type", function() {
+                spyOn(ctrl, 'viewAll').and.callThrough();
+                ctrl.viewAll({"request": {
+                        "filters": {
+                        "objectType": [
+                            "Resource"
+                        ]}}});
+                expect(ctrl.filterSelection.contentType).toEqual("Resource");
+            });
+            it("ContentType filter should prefilled with Collection type", function() {
+                spyOn(ctrl, 'viewAll').and.callThrough();
+                ctrl.viewAll({"request": {
+                        "filters": {
+                        "objectType": [
+                            "Collection"
+                        ]}}});
+                expect(ctrl.filterSelection.contentType).toEqual(["Collection"]);
+            });
+            it("CURRICULUM filter should prefilled with ICSE", function() {
+                spyOn(ctrl, 'viewAll').and.callThrough();
+                ctrl.viewAll({"request": {
+                        "filters": {
+                        "board": [
+                            "ICSE"
+                        ]}}});
+                expect(ctrl.filterSelection.board).toEqual(["ICSE"]);
+            });
+            it("CLASS filter should prefilled with Class 1", function() {
+                spyOn(ctrl, 'viewAll').and.callThrough();
+                ctrl.viewAll({"request": {
+                        "filters": {
+                        "gradeLevel": [
+                            "Class 1"
+                        ]}}});
+                expect(ctrl.filterSelection.gradeLevel).toEqual(["Class 1"]);
+            });
+            it("SUBJECT  filter should prefilled with English", function() {
+                spyOn(ctrl, 'viewAll').and.callThrough();
+                ctrl.viewAll({"request": {
+                        "filters": {
+                        "subject": [
+                            "English"
+                        ]}}});
+                expect(ctrl.filterSelection.subject).toEqual(["English"]);
+            });
+            it("MEDIUM  filter should prefilled with English", function() {
+                spyOn(ctrl, 'viewAll').and.callThrough();
+                ctrl.viewAll({"request": {
+                        "filters": {
+                        "medium": [
+                            "English"
+                        ]}}});
+                expect(ctrl.filterSelection.medium).toEqual(["English"]);
+            });
         });
     });
 });

--- a/org.ekstep.lessonbrowser-1.4/test/editor/plugin.spec.js
+++ b/org.ekstep.lessonbrowser-1.4/test/editor/plugin.spec.js
@@ -1,12 +1,10 @@
 describe("lesson browser plugin", function() {
     var manifest, path, ctrl, $scope, pluginInstance;
     beforeAll(function(done) {
-       org.ekstep.pluginframework.pluginManager.loadPlugin('org.ekstep.lessonbrowser', '1.4', function() {
-            manifest = org.ekstep.pluginframework.pluginManager.getPluginManifest("org.ekstep.lessonbrowser");
-            path = ecEditor.resolvePluginResource(manifest.id, manifest.ver, "editor/lessonBrowserApp.js");
-            pluginInstance = org.ekstep.pluginframework.pluginManager.pluginObjs["org.ekstep.lessonbrowser"];
-            done();
-        });
+        manifest = org.ekstep.pluginframework.pluginManager.getPluginManifest("org.ekstep.lessonbrowser");
+        path = ecEditor.resolvePluginResource(manifest.id, manifest.ver, "editor/lessonBrowserApp.js");
+        pluginInstance = org.ekstep.pluginframework.pluginManager.pluginObjs["org.ekstep.lessonbrowser"];
+        done();
     });
 
     it('mock controller', function(done) {
@@ -135,6 +133,49 @@ describe("lesson browser plugin", function() {
                             "English"
                         ]}}});
                 expect(ctrl.filterSelection.medium).toEqual(["English"]);
+            });
+        });
+        describe("Apply rootNode Metadata", function() {
+            it("If root node having NCERT board, filters should be prefilled as NCERT board", function() {
+                spyOn(ctrl, 'viewAll').and.callThrough();
+                ctrl.viewAll({"request": {
+                        "filters": {
+                        "objectType": [
+                            "Resource"
+                        ]}}});
+                $scope.contentMeta.board = ["NCERT"]; 
+                expect($scope.rootNodeFilter.board).toEqual($scope.contentMeta.board);
+            });
+            it("If root node having NCERT board and Query having NCF, filters should be prefilled as NCERT, NCF board", function() {
+                spyOn(ctrl, 'viewAll').and.callThrough();
+                ctrl.viewAll({"request": {
+                        "filters": {
+                        "board":["NCF"], 
+                        "objectType": [
+                            "Resource"
+                        ]}}});
+                $scope.contentMeta.board = ["NCERT"]; 
+                expect($scope.rootNodeFilter.board).toEqual($scope.contentMeta.board);
+            });
+            it("If root node having English medium, filters should be prefilled as English medium", function() {
+                spyOn(ctrl, 'viewAll').and.callThrough();
+                ctrl.viewAll({"request": {
+                        "filters": {
+                        "objectType": [
+                            "Resource"
+                        ]}}});
+                $scope.contentMeta.medium = ["English"]; 
+                expect($scope.rootNodeFilter.medium).toEqual($scope.contentMeta.medium);
+            });
+            it("If root node having English subject, filters should be prefilled as English subject", function() {
+                spyOn(ctrl, 'viewAll').and.callThrough();
+                ctrl.viewAll({"request": {
+                        "filters": {
+                        "objectType": [
+                            "Resource"
+                        ]}}});
+                $scope.contentMeta.subject = ["English"]; 
+                expect($scope.rootNodeFilter.subject).toEqual($scope.contentMeta.subject);
             });
         });
     });


### PR DESCRIPTION
Issue #SB-6241 fix: Test cases - Dynamic filters for resource browser

```lesson browser plugin
    ✔ mock controller
    Lesson browser
      Init lesson browser
        ✔ It should initialized Lesson browser plugin
        ✔ Should initialize the lesson browser with filters
        ✔ By dispatching editor:invoke:viewall event init preview should called
      View all
        ✔ ContentType filter should prefilled with Resource type
        ✔ ContentType filter should prefilled with Collection type
        ✔ CURRICULUM filter should prefilled with ICSE
        ✔ CLASS filter should prefilled with Class 1
        ✔ SUBJECT  filter should prefilled with English
        ✔ MEDIUM  filter should prefilled with English
```
```
80% Statements 
12/15 100% Branches 
4/4 33.33% Functions 
2/6 80% Lines 
12/15
```