### PR TITLE
Issue #SB-7213 fix: Richtext wysiwyg

### DIFF
--- a/org.ekstep.richtext-1.0/editor/configTemplate.html
+++ b/org.ekstep.richtext-1.0/editor/configTemplate.html
@@ -1,0 +1,5 @@
+<div class="ui accordion sidebar-accordion">
+    <div class="title" id="editRichtext">
+        Edit Richtext
+    </div>
+</div>

--- a/org.ekstep.richtext-1.0/editor/configTemplate.html
+++ b/org.ekstep.richtext-1.0/editor/configTemplate.html
@@ -1,5 +1,5 @@
 <div class="ui accordion sidebar-accordion">
-    <div class="title" id="editRichtext">
+    <div class="title" id="editRichtext" ng-click="fireEvent({id:'org.ekstep.richtext:showpopup', 'data': {textSelected: true}}); $event.stopPropagation();">
         Edit Richtext
     </div>
 </div>

--- a/org.ekstep.richtext-1.0/editor/libs/config.js
+++ b/org.ekstep.richtext-1.0/editor/libs/config.js
@@ -29,10 +29,11 @@ CKEDITOR.editorConfig = function( config ) {
 	// config.fontSize_defaultLabel = '18';
 
 	// Font family to show in dropdown
-	config.font_names = 'NotoSans;NotoSansBengali;NotoSansDevanagari;NotoSansGujarati;NotoSansGurmukhi;NotoSansKannada;NotoSansMalayalam;NotoSansOriya;NotoSansTamil;NotoSansTelugu;NotoNastaliqUrdu';
+	//config.font_names = 'NotoSans;NotoSansBengali;NotoSansDevanagari;NotoSansGujarati;NotoSansGurmukhi;NotoSansKannada;NotoSansMalayalam;NotoSansOriya;NotoSansTamil;NotoSansTelugu;NotoNastaliqUrdu';
+	config.font_names = 'বাংলা (Bengali)/NotoSansBengali;देवनागरी (Devanagari)/NotoSansDevanagari;English & other languages/NotoSans;ગુજરાતી (Gujarati)/NotoSansGujarati;ਗੁਰਮੁਖੀ (Gurmukhi)/NotoSansGurmukhi;ಕನ್ನಡ (Kannada)/NotoSansKannada;മലയാളലിപി (Malayalam)/NotoSansMalayalam;ଓଡ଼ିଆ (Oriya)/NotoSansOriya;தமிழ் (Tamil)/NotoSansTamil;తెలుగు (Telugu)/NotoSansTelugu;اردو (Urdu)/NotoNastaliqUrdu';
 
 	// Default font family
-	config.font_defaultLabel = 'NotoSans';
+	config.font_defaultLabel = 'English & other languages';
 
 	config.removePlugins = 'stylescombo, magicline';
 

--- a/org.ekstep.richtext-1.0/editor/libs/config.js
+++ b/org.ekstep.richtext-1.0/editor/libs/config.js
@@ -28,11 +28,17 @@ CKEDITOR.editorConfig = function( config ) {
 
 	// config.fontSize_defaultLabel = '18';
 
+	// Font family to show in dropdown
+	config.font_names = 'NotoSans;NotoSansBengali;NotoSansDevanagari;NotoSansGujarati;NotoSansGurmukhi;NotoSansKannada;NotoSansMalayalam;NotoSansOriya;NotoSansTamil;NotoSansTelugu;NotoNastaliqUrdu';
+
+	// Default font family
+	config.font_defaultLabel = 'NotoSans';
+
 	config.removePlugins = 'stylescombo, magicline';
 
 	// Remove some buttons provided by the standard plugins, which are
 	// not needed in the Standard(s) toolbar.
-	config.removeButtons = 'Underline,Subscript,Superscript,Font';
+	config.removeButtons = 'Underline,Subscript,Superscript';
 
 	// Set the most common block elemnts.
 	config.format_tags = 'p;h1;h2;h3';

--- a/org.ekstep.richtext-1.0/editor/libs/contents.css
+++ b/org.ekstep.richtext-1.0/editor/libs/contents.css
@@ -6,7 +6,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 body
 {
 	/* Font */
-	font-family: sans-serif;
+	font-family: NotoSans;
 	font-size: 18px;
 
 	/* Text color */

--- a/org.ekstep.richtext-1.0/editor/plugin.js
+++ b/org.ekstep.richtext-1.0/editor/plugin.js
@@ -111,6 +111,9 @@ org.ekstep.contenteditor.basePlugin.extend({
      */
     selected: function(instance) {
         fabric.util.addListener(fabric.document, 'dblclick', this.dblClickHandler);
+        $(document).on('click', '#editRichtext', function() {
+            ecEditor.dispatchEvent("org.ekstep.richtext:showpopup", {textSelected: true})
+        })
     },
 
     /**
@@ -119,6 +122,7 @@ org.ekstep.contenteditor.basePlugin.extend({
      */
     deselected: function(instance, options, event) {
         fabric.util.removeListener(fabric.document, 'dblclick', this.dblClickHandler);
+        $('#editRichtext').off('click')
     },
 
     removed: function(instance, options, event) {

--- a/org.ekstep.richtext-1.0/editor/plugin.js
+++ b/org.ekstep.richtext-1.0/editor/plugin.js
@@ -122,7 +122,7 @@ org.ekstep.contenteditor.basePlugin.extend({
      */
     deselected: function(instance, options, event) {
         fabric.util.removeListener(fabric.document, 'dblclick', this.dblClickHandler);
-        $('#editRichtext').off('click')
+        $(document).off('click', '#editRichtext')
     },
 
     removed: function(instance, options, event) {

--- a/org.ekstep.richtext-1.0/editor/plugin.js
+++ b/org.ekstep.richtext-1.0/editor/plugin.js
@@ -51,6 +51,7 @@ org.ekstep.contenteditor.basePlugin.extend({
         ecEditor.getService('popup').loadNgModules(templatePath, controllerPath);
         var divWrapper = document.createElement('div');
         divWrapper.setAttribute("id", this.richTextId);
+        divWrapper.setAttribute("class", this.richTextId);
         ecEditor.jQuery(".canvas-container").append(divWrapper);
     },
 
@@ -111,9 +112,6 @@ org.ekstep.contenteditor.basePlugin.extend({
      */
     selected: function(instance) {
         fabric.util.addListener(fabric.document, 'dblclick', this.dblClickHandler);
-        $(document).on('click', '#editRichtext', function() {
-            ecEditor.dispatchEvent("org.ekstep.richtext:showpopup", {textSelected: true})
-        })
     },
 
     /**
@@ -122,7 +120,6 @@ org.ekstep.contenteditor.basePlugin.extend({
      */
     deselected: function(instance, options, event) {
         fabric.util.removeListener(fabric.document, 'dblclick', this.dblClickHandler);
-        $(document).off('click', '#editRichtext')
     },
 
     removed: function(instance, options, event) {

--- a/org.ekstep.richtext-1.0/editor/plugin.js
+++ b/org.ekstep.richtext-1.0/editor/plugin.js
@@ -33,7 +33,6 @@ org.ekstep.contenteditor.basePlugin.extend({
      * @memberof RichText
      */
     richTextId: 'richtext-wrapper',
-    supportedFonts: 'NotoSans, NotoSansBengali, NotoSansDevanagari, NotoSansGujarati, NotoSansGurmukhi, NotoSansKannada, NotoSansMalayalam, NotoSansOriya, NotoSansTamil, NotoSansTelugu, NotoNastaliqUrdu',
     /**
      * The events are registred which are used to add or remove fabric events and other custom events
      * @memberof RichText
@@ -82,13 +81,13 @@ org.ekstep.contenteditor.basePlugin.extend({
     resizeObject: function(e) {
         if (ecEditor.getCurrentObject() && ecEditor.getCurrentObject().manifest.id == 'org.ekstep.richtext') {
                var canvasCord = ecEditor.jQuery('#canvas').offset();
-               var editorObject = ecEditor.getCurrentObject().editorObj;
+               var editorObject = ecEditor.getCurrentObject();
                ecEditor.jQuery("#" + e.target.id).offset({
                      'top':e.target.top + canvasCord.top, 
                      'left':e.target.left + canvasCord.left
                });
-               editorObject.width =  e.target.getWidth();
-               editorObject.height =  e.target.getHeight();
+               editorObject.attributes.w =  e.target.getWidth();
+               editorObject.attributes.h =  e.target.getHeight();
                ecEditor.jQuery("#" + e.target.id).width(e.target.getWidth());
                ecEditor.jQuery("#" + e.target.id).height(e.target.getHeight());
         }
@@ -138,7 +137,7 @@ org.ekstep.contenteditor.basePlugin.extend({
         div.setAttribute("id", instance.data.id);
         div.style.position = 'absolute';
         div.style.fontSize = '14px';
-        div.style.fontFamily = this.supportedFonts;
+        div.style.fontFamily = 'NotoSans';
         div.style.width = instance.data.editorObj.width ? instance.data.editorObj.width + 1 + 'px' : "auto";
         div.style.height = instance.data.editorObj.height ? instance.data.editorObj.height + 1 + 'px' : "auto";
         div.style.pointerEvents = "none";
@@ -217,7 +216,6 @@ org.ekstep.contenteditor.basePlugin.extend({
      getAttributes: function() {
         var attributes = this._super();
         attributes.fontSize = this.updateFontSize(ecEditor.jQuery('#' + this.richTextId).css("font-size"), false);
-        attributes.font = this.supportedFonts;
         return attributes;
     },
 

--- a/org.ekstep.richtext-1.0/editor/plugin.js
+++ b/org.ekstep.richtext-1.0/editor/plugin.js
@@ -33,6 +33,7 @@ org.ekstep.contenteditor.basePlugin.extend({
      * @memberof RichText
      */
     richTextId: 'richtext-wrapper',
+    supportedFonts: 'NotoSans, NotoSansBengali, NotoSansDevanagari, NotoSansGujarati, NotoSansGurmukhi, NotoSansKannada, NotoSansMalayalam, NotoSansOriya, NotoSansTamil, NotoSansTelugu, NotoNastaliqUrdu',
     /**
      * The events are registred which are used to add or remove fabric events and other custom events
      * @memberof RichText
@@ -137,7 +138,7 @@ org.ekstep.contenteditor.basePlugin.extend({
         div.setAttribute("id", instance.data.id);
         div.style.position = 'absolute';
         div.style.fontSize = '14px';
-        div.style.fontFamily = 'NotoSans';
+        div.style.fontFamily = this.supportedFonts;
         div.style.width = instance.data.editorObj.width ? instance.data.editorObj.width + 1 + 'px' : "auto";
         div.style.height = instance.data.editorObj.height ? instance.data.editorObj.height + 1 + 'px' : "auto";
         div.style.pointerEvents = "none";
@@ -216,6 +217,7 @@ org.ekstep.contenteditor.basePlugin.extend({
      getAttributes: function() {
         var attributes = this._super();
         attributes.fontSize = this.updateFontSize(ecEditor.jQuery('#' + this.richTextId).css("font-size"), false);
+        attributes.font = this.supportedFonts;
         return attributes;
     },
 
@@ -226,7 +228,7 @@ org.ekstep.contenteditor.basePlugin.extend({
     getConfig: function() {
         var config = this._super();
         // config.color = ecEditor.jQuery('#' + this.id).css("color");
-        config.fontfamily = ecEditor.jQuery('#' + this.id).css("font-family");
+        // config.fontfamily = ecEditor.jQuery('#' + this.id).css("font-family");
         config.fontsize = ecEditor.jQuery('#' + this.id).css("font-size");
         config = _.omit(config, ["stroke", "strokeWidth"]);
         return config;

--- a/org.ekstep.richtext-1.0/editor/richtexteditor.html
+++ b/org.ekstep.richtext-1.0/editor/richtexteditor.html
@@ -17,9 +17,18 @@
         </div>
         <div class="actions">
             <div class="ui buttons">
-                <button class="ui orange button" ng-click="closeThisDialog()" type="button">Cancel</button>
-                <div class="or"></div>
-                <button class="ui blue button" id="addLesson" type="button" ng-click="$ctrl.addText()">Add To Lesson</button>
+                <div class="ui grid">
+                    <div class="eight wide column left aligned">
+                        <p>Please select appropriate font name (typeface) as per the language of your text.</p>
+                    </div>
+                    <div class="four wide column right aligned">
+                        <div class="ui buttons" style="margin:0;">
+                            <button class="ui orange button" ng-click="closeThisDialog()" type="button">Cancel</button>
+                            <div class="or"></div>
+                            <button class="ui blue button" id="addLesson" type="button" ng-click="$ctrl.addText()">Add To Lesson</button>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/org.ekstep.richtext-1.0/editor/style.css
+++ b/org.ekstep.richtext-1.0/editor/style.css
@@ -41,5 +41,5 @@
 }
 
 #editRichtext {
-    padding-top: 20px;
+    border-bottom: 0.1px solid #d2d3d5 !important;
 }

--- a/org.ekstep.richtext-1.0/editor/style.css
+++ b/org.ekstep.richtext-1.0/editor/style.css
@@ -30,3 +30,12 @@
 #richtext-wrapper div h6 {
     font-size: 0.67em;
 }
+
+/*setting ckeditor dropdown width */
+.cke_combopanel__font, .cke_combopanel__format {
+    width: 200px !important;
+}
+
+.cke_combopanel__fontsize {
+    width: 175px !important;
+}

--- a/org.ekstep.richtext-1.0/editor/style.css
+++ b/org.ekstep.richtext-1.0/editor/style.css
@@ -1,0 +1,32 @@
+#richtext-wrapper div * {
+    line-height: 1.3 !important;
+}
+
+#richtext-wrapper p {
+    margin: 0 0 0 !important;
+}
+
+#richtext-wrapper div h1 {
+    min-height: 1rem;
+    font-size: 2rem;
+}
+
+#richtext-wrapper div h2 {
+    font-size: 1.71428571rem;
+}
+
+#richtext-wrapper div h3 {
+    font-size: 1.28571429rem;
+}
+
+#richtext-wrapper div h4 {
+    font-size: 1.07142857rem;
+}
+
+#richtext-wrapper div h5 {
+    font-size: 1rem;
+}
+
+#richtext-wrapper div h6 {
+    font-size: 0.67em;
+}

--- a/org.ekstep.richtext-1.0/editor/style.css
+++ b/org.ekstep.richtext-1.0/editor/style.css
@@ -39,3 +39,7 @@
 .cke_combopanel__fontsize {
     width: 175px !important;
 }
+
+#editRichtext {
+    padding-top: 20px;
+}

--- a/org.ekstep.richtext-1.0/editor/style.css
+++ b/org.ekstep.richtext-1.0/editor/style.css
@@ -1,33 +1,33 @@
-#richtext-wrapper div * {
+.richtext-wrapper div * {
     line-height: 1.3 !important;
 }
 
-#richtext-wrapper p {
+.richtext-wrapper p {
     margin: 0 0 0 !important;
 }
 
-#richtext-wrapper div h1 {
+.richtext-wrapper div h1 {
     min-height: 1rem;
     font-size: 2rem;
 }
 
-#richtext-wrapper div h2 {
+.richtext-wrapper div h2 {
     font-size: 1.71428571rem;
 }
 
-#richtext-wrapper div h3 {
+.richtext-wrapper div h3 {
     font-size: 1.28571429rem;
 }
 
-#richtext-wrapper div h4 {
+.richtext-wrapper div h4 {
     font-size: 1.07142857rem;
 }
 
-#richtext-wrapper div h5 {
+.richtext-wrapper div h5 {
     font-size: 1rem;
 }
 
-#richtext-wrapper div h6 {
+.richtext-wrapper div h6 {
     font-size: 0.67em;
 }
 

--- a/org.ekstep.richtext-1.0/manifest.json
+++ b/org.ekstep.richtext-1.0/manifest.json
@@ -10,7 +10,8 @@
     "editor": {
         "main": "editor/plugin.js",
         "dependencies": [
-            { "type": "js", "src": "editor/libs/ckeditor.js" }
+            { "type": "js", "src": "editor/libs/ckeditor.js" },
+            { "type": "css", "src": "editor/style.css" }
         ],
         "views":[
             {"template":"./richtexteditor.html", "controller":"./richtexteditorapp.js"}

--- a/org.ekstep.richtext-1.0/manifest.json
+++ b/org.ekstep.richtext-1.0/manifest.json
@@ -19,7 +19,10 @@
         "behaviour": {
             "rotatable": false
         },
-        "configManifest": [],
+        "configManifest": [{
+            "type": "custom_template",
+            "templateURL": "editor/configTemplate.html"
+        }],
         "help": {
             "src": "editor/help.md",
             "dataType": "text"

--- a/org.ekstep.richtext-1.0/renderer/richtextrendererplugin.js
+++ b/org.ekstep.richtext-1.0/renderer/richtextrendererplugin.js
@@ -37,7 +37,7 @@ Plugin.extend({
         div.style.position = 'absolute';
         var fontSize = this.updateFontSize(parseFloat(data.fontSize));
         div.style.fontSize = fontSize + 'px';
-        // div.style.fontFamily = data.font;
+        div.style.fontFamily = data.font;
         // div.style.fontWeight = this._plginConfig.fontweight ? "bold" : "normal";
         // div.style.fontStyle = this._plginConfig.fontstyle ?  "italic" : "normal";
         div.style.color = data.color;
@@ -53,11 +53,6 @@ Plugin.extend({
         this._self.y = dims.y;
     },
     updateFontSize: function(initFontSize) {
-        var canvas = EkstepRendererAPI.getCanvas();
-        var canvasDim = {
-            width: canvas.width,
-            height: canvas.height,
-        }
         // Convert fontSize to pixel based on device dimensions
         var exp = parseFloat(PluginManager.defaultResWidth * this.relativeDims().w / 100);
         var cw = this._parent.dimensions().w;

--- a/org.ekstep.stage-1.0/editor/plugin.js
+++ b/org.ekstep.stage-1.0/editor/plugin.js
@@ -62,7 +62,6 @@ org.ekstep.contenteditor.basePlugin.extend({
             html2canvas($('#canvas-wrapper'), {  
                 onrendered: function (canvas) {
                     stage.thumbnail = canvas.toDataURL({format: 'jpeg', quality: 0.1});
-                    org.ekstep.contenteditor.stageManager.thumbnails[stage.id] = stage.thumbnail;
                     var angScope = ecEditor.getAngularScope();
                     ecEditor.ngSafeApply(angScope);
                 }

--- a/org.ekstep.stage-1.0/editor/plugin.js
+++ b/org.ekstep.stage-1.0/editor/plugin.js
@@ -62,6 +62,7 @@ org.ekstep.contenteditor.basePlugin.extend({
             html2canvas($('#canvas-wrapper'), {  
                 onrendered: function (canvas) {
                     stage.thumbnail = canvas.toDataURL({format: 'jpeg', quality: 0.1});
+                    org.ekstep.contenteditor.stageManager.thumbnails[stage.id] = stage.thumbnail;
                     var angScope = ecEditor.getAngularScope();
                     ecEditor.ngSafeApply(angScope);
                 }


### PR DESCRIPTION
Added seperate css file for richtext.
Added font family in ckeditor(default is notosans)
Added sidebar config **Edit Richtext** button which will open richtext editor
Fixed resizing of richtext issue(resize width is resizing height also & vice versa)

Please merge Below PR also with this PR as all are related to richtext else richtext functionality will break
https://github.com/project-sunbird/sunbird-content-editor/pull/15
https://github.com/project-sunbird/sunbird-content-player/pull/47

**Test Content:**
Richtext New - https://ekstep-public-dev.s3-ap-south-1.amazonaws.com/ecar_files/do_1125903380079001601158/rich-text-old_1538583235448_do_1125903380079001601158_1.0.ecar

Richtext Old - https://ekstep-public-dev.s3-ap-south-1.amazonaws.com/content/do_11253525264863232015/artifact/1537783008565_do_11253525264863232015.zip