### PR TITLE
SB-6070 fix:Should not load loader when click on disable reload button.

### DIFF
--- a/org.ekstep.suggestcontent-1.1/editor/suggestContent.html
+++ b/org.ekstep.suggestcontent-1.1/editor/suggestContent.html
@@ -4,7 +4,7 @@
             <a><i class="angle right icon color-blue"></i></a>
             <span class="suggest-content-header-title">Explore Suggestions</span>
             <span ng-class="suggestedContentList.content.length ? 'color-blue' : 'disabled'" class="float-right">
-                <i ng-click="refreshSuggestions(); generateTelemetry({type: 'click', subtype: 'RefreshContentButton', target: 'Refresh Content'})"
+                <i ng-click="suggestedContentList.content.length === 0 || refreshSuggestions(); generateTelemetry({type: 'click', subtype: 'RefreshContentButton', target: 'Refresh Content'})"
                     ng-class="suggestedContentList.content.length ? 'color-blue' : 'disabled'" class="undo icon refresh-btn"></i>
                 <span ng-click="openResourceBrowser();generateTelemetry({type: 'click', subtype: 'ViewAllButton', target: 'View All'})" class="padding-right-20 padding-left-8">View All</span>
             </span>


### PR DESCRIPTION
**Ref:** https://project-sunbird.atlassian.net/browse/SB-6070

**Description:**
Whenever user clicks on "Reload" button under "Explore Suggestions" it shows a loader even if there is no content and the reload button is disabled.'

