### PR TITLE
Issue #SB-4552 fix: Dial code update message should not display when dial code is empty.

### DIFF
--- a/org.ekstep.contenteditorfunctions-1.2/editor/plugin.js
+++ b/org.ekstep.contenteditorfunctions-1.2/editor/plugin.js
@@ -515,7 +515,12 @@ org.ekstep.contenteditor.basePlugin.extend({
                             position: 'topCenter',
                             icon: 'fa fa-warning'
                         });
-                    }else if(dialcodeMapObj && dialcodeMapObj.dialcode) {
+                    }else if((dialcodeMapObj && dialcodeMapObj.dialcode) || (org.ekstep.services.collectionService.dialcodeList.length > 0 && org.ekstep.services.stateService.state.dialCodeMap)) {
+                        if(dialcodeMapObj && dialcodeMapObj.dialcode) {
+                            org.ekstep.services.collectionService.dialcodeList = dialcodeMapObj.dialcode;
+                        } else {
+                            org.ekstep.services.collectionService.dialcodeList = [];
+                        }
                         ecEditor.dispatchEvent("org.ekstep.toaster:success", {
                             title: 'DIAL code(s) updated successfully!',
                             position: 'topCenter',

--- a/org.ekstep.contenteditorfunctions-1.2/editor/plugin.js
+++ b/org.ekstep.contenteditorfunctions-1.2/editor/plugin.js
@@ -500,6 +500,7 @@ org.ekstep.contenteditor.basePlugin.extend({
         instance.dialcodeLink(mapArr);
     },
     dialcodeLink: function(dialcodeMap) {
+        var dialcodeMapObj = _.find(dialcodeMap, 'dialcode');
         if(!_.isEmpty(dialcodeMap)){
             var request = {
                 "request": {
@@ -514,7 +515,7 @@ org.ekstep.contenteditor.basePlugin.extend({
                             position: 'topCenter',
                             icon: 'fa fa-warning'
                         });
-                    }else{
+                    }else if(dialcodeMapObj && dialcodeMapObj.dialcode) {
                         ecEditor.dispatchEvent("org.ekstep.toaster:success", {
                             title: 'DIAL code(s) updated successfully!',
                             position: 'topCenter',
@@ -539,7 +540,7 @@ org.ekstep.contenteditor.basePlugin.extend({
     },
     storeDialCodes: function(nodeId, dialCode){
         var node = ecEditor.getService(ServiceConstants.COLLECTION_SERVICE).getNodeById(nodeId);
-        if(node && node.data)
+        if(node && node.data) 
             node.data.metadata["dialcodes"] = dialCode;
     },
     hightlightNode: function(invalidNodes) {

--- a/org.ekstep.contenteditorfunctions-1.2/test/editor/plugin.spec.js
+++ b/org.ekstep.contenteditorfunctions-1.2/test/editor/plugin.spec.js
@@ -1,0 +1,45 @@
+describe("Ekstep contenteditorfunction Plugin:", function() {
+    var manifest, ctrl, $scope, pluginInstance;
+    var instance = { manifest: {id: "org.ekstep.contenteditorfunctions", ver: "1.2"}, "data":""};
+    
+    beforeAll(function(done) {
+        manifest = org.ekstep.pluginframework.pluginManager.getPluginManifest("org.ekstep.contenteditorfunctions");
+        path = ecEditor.resolvePluginResource(manifest.id, manifest.ver, "editor/plugin.js");
+        pluginInstance = ecEditor.instantiatePlugin("org.ekstep.contenteditorfunctions");
+        done();
+    });
+
+    describe('contenteditor plugin test cases', function() {
+        it('Should invoke dialcodelink method to save dialcode if dialcode is not empty', function (done) {
+            var dialcodeMap = {identifier: "do_112598146652307456120", dialcode: "G6V1VN"};
+            var request = {"request":{"content":[{"identifier":"do_112598146652307456120","dialcode":""}]}};
+            spyOn(pluginInstance, "dialcodeLink").and.callThrough();
+            pluginInstance.dialcodeLink(dialcodeMap);
+            expect(pluginInstance.dialcodeLink).not.toBeUndefined();
+            expect(pluginInstance.dialcodeLink).toHaveBeenCalled();
+            spyOn(ecEditor.getService('dialcode'), "dialcodeLink").and.callThrough();
+            expect(ecEditor.getService('dialcode').dialcodeLink);
+            done();
+        });
+
+        it('Should invoke dialcodelink method to save dialcode if dialcode is empty', function (done) {
+            var dialcodeMap = {identifier: "do_112598146652307456120", dialcode: ""};
+            spyOn(pluginInstance, "dialcodeLink").and.callThrough();
+            pluginInstance.dialcodeLink(dialcodeMap);
+            expect(pluginInstance.dialcodeLink).not.toBeUndefined();
+            expect(pluginInstance.dialcodeLink).toHaveBeenCalled();
+            done();
+        });
+
+        it('Should invoke dialcodelink method to save dialcode and dialcode is undefined', function (done) {
+            var dialcodeMap = undefined;
+            org.ekstep.services.stateService.state = {'invaliddialCodeMap':'invalid'};
+            spyOn(pluginInstance, "dialcodeLink").and.callThrough();
+            pluginInstance.dialcodeLink(dialcodeMap);
+            expect(pluginInstance.dialcodeLink).not.toBeUndefined();
+            expect(pluginInstance.dialcodeLink).toHaveBeenCalled();
+            done();
+        });
+    
+    });
+})


### PR DESCRIPTION
**Ref:** https://project-sunbird.atlassian.net/browse/SB-4552

**Description:**
Dial code update successfully message is displaying when there is no dial code in dial code field on Edit details page.