### PR TITLE
When user try to use Search option in from  Add Resource window while Book Creation then filter is not working.

### DIFF
--- a/org.ekstep.lessonbrowser-1.4/editor/lessonBrowserApp.js
+++ b/org.ekstep.lessonbrowser-1.4/editor/lessonBrowserApp.js
@@ -189,7 +189,6 @@ angular.module('org.ekstep.lessonbrowserapp', ['angular-inview', 'luegg.directiv
             } else {
                 $scope.isLoading = true;
             }
-            $scope.filterSelection.lessonType = searchBody.request.filters.contentType;
             ctrl.searchRes = { count: 0, content: [] };
             searchBody.request.query = this.searchKeyword;
             delete searchBody.request.filters.name;


### PR DESCRIPTION
**Ref:** https://project-sunbird.atlassian.net/browse/SB-9660

**Description:**
When user try to use Search option in from  Add Resource window while Book Creation then filter is not working and giving error message resources not  found even resources are available.