### PR TITLE
Issue #8747 fix:Reduce margin when adding mathematical formula in paragraph line.

### DIFF
--- a/org.ekstep.questionunit-1.0/renderer/components/css/components.css
+++ b/org.ekstep.questionunit-1.0/renderer/components/css/components.css
@@ -5,7 +5,7 @@ body {
 
 /* overiding katex css */
 .math-text .katex-display {
-    margin: 0.5em 0 !important;
+    margin: 0.2em 0 !important;
 }
 
 /*end */


### PR DESCRIPTION
**Ref:** https://project-sunbird.atlassian.net/browse/SB-8747

**Description:** 
Add question : Paragraph text is taking more line spaces when adding an equation into it.