### PR TITLE
Issue #sB-10476 fix:Should display alert message when closing editor without save the changes.

### DIFF
--- a/org.ekstep.sunbirdcommonheader-1.9/editor/headerApp.js
+++ b/org.ekstep.sunbirdcommonheader-1.9/editor/headerApp.js
@@ -420,6 +420,8 @@ angular.module('org.ekstep.sunbirdcommonheader:app', ["Scope.safeApply", "yaru22
         if($scope.editorEnv === "COLLECTION"){
             $scope.pendingChanges = ecEditor.getConfig('editorConfig').mode === 'Read' ? false : true;
             $scope.disableTocActionBtn = true;
+        } else {
+            $scope.pendingChanges = true;
         }
         $scope.disableSaveBtn = false;
         $scope.disableQRGenerateBtn = false;

--- a/org.ekstep.sunbirdcommonheader-1.9/test/editor/plugin.spec.js
+++ b/org.ekstep.sunbirdcommonheader-1.9/test/editor/plugin.spec.js
@@ -113,6 +113,34 @@ describe("Sunbird header plugin:", function() {
             done();
         });
 
+        it("Should called setPendingChangingStatus method and enable pendingChanges if any changes in conent", function(done) {
+            var event = {"type":"org.ekstep.collectioneditor:node:modified"};
+            var data = {};
+            var meta = ecEditor.getService(ServiceConstants.CONTENT_SERVICE).getContentMeta(ecEditor.getContext('contentId'));
+            switch (meta.mimeType) {
+                case "application/vnd.ekstep.ecml-archive":
+                    $scope.editorEnv = "ECML"
+                    break;
+                case "application/vnd.ekstep.content-collection":
+                    $scope.editorEnv = "COLLECTION"
+                    break;
+                default:
+                    $scope.editorEnv = "NON-ECML"
+                    break;
+            };
+            spyOn($scope, "setPendingChangingStatus").and.callThrough();
+            $scope.setPendingChangingStatus(event, data);
+            if($scope.editorEnv === "COLLECTION") {
+                $scope.pendingChanges = ecEditor.getConfig('editorConfig').mode === 'Read' ? false : true;
+                $scope.disableTocActionBtn = true;
+            } else {
+                $scope.pendingChanges = true;
+            }
+            expect($scope.setPendingChangingStatus).toHaveBeenCalled();
+            done();
+        });
+
+
         it("Should invoke addListSize method to increase listSize", function(done) {
             spyOn($scope, "addListSize").and.callThrough();
             $scope.addListSize();


### PR DESCRIPTION
**Ref:** https://project-sunbird.atlassian.net/browse/SB-10476

**Description:**
Resource Creation : When user closes the editor without saving the content it does not display a warning message "You have unsaved changes! Do you want to leave?".