### PR TITLE
Issue #SB-11398 fix:initialize time every time when click on add resource

### DIFF
--- a/org.ekstep.lessonbrowser-1.5/editor/plugin.js
+++ b/org.ekstep.lessonbrowser-1.5/editor/plugin.js
@@ -33,6 +33,7 @@ org.ekstep.collectioneditor.basePlugin.extend({
      */
     initPreview: function(event, params) {
         var instance = this;
+        instance.startLoadTime = new Date(); 
         instance.client = params.client;
         instance.query = params.query;
         cb = params.callback || function() {};


### PR DESCRIPTION
**Ref:** https://project-sunbird.atlassian.net/browse/SB-11398

Time should initialize every click on add resource in collection editor.
