### PR TITLE
Issue #SB-11814 fix: image overlapping with text in ftb content.

### DIFF
--- a/org.ekstep.keyboard-1.1/renderer/style/style.css
+++ b/org.ekstep.keyboard-1.1/renderer/style/style.css
@@ -29,7 +29,7 @@
   width: 50%;
   margin: 0 auto;
   top: 33%;
-  margin-left: 24%;
+  margin-left: 28%;
 }
 
 .parentDivMainKeyboard,


### PR DESCRIPTION
**Ref: ** https://project-sunbird.atlassian.net/browse/SB-11814

**Description:**
FTB: When image is added in FTB question and for custom or english keyboard the Enter answer tab is overlapping on the image added