### PR TITLE
Issue #SB-11876 fix:corrected level spelling in qr warning message

### DIFF
--- a/org.ekstep.sunbirdcommonheader-1.9/editor/sendForReviewWarning.html
+++ b/org.ekstep.sunbirdcommonheader-1.9/editor/sendForReviewWarning.html
@@ -5,7 +5,7 @@
     </div>
     <div class="content">
         <h4  style="font-weight: bold;font-size: 18px;">Are you sure you want to submit for review without QR code?</h4>
-        <p>you haven't added any Textbook levele QR code.</p>
+        <p>You haven't added any Textbook level QR code.</p>
     </div>
     <div class="actions footer">
       <div class="ui buttons ">


### PR DESCRIPTION
**Ref:** https://project-sunbird.atlassian.net/browse/SB-11876

**Description:**
Level spelling is displayed as "Levele" in the "QR Code Missing" pop-up for textbook unit.