### PR TITLE
Issue #SB-12290 fix:Should not display error message when qr code selected no.

### DIFF
--- a/org.ekstep.unitmeta-1.7/editor/directives/dialCode/dialCodeDirective.js
+++ b/org.ekstep.unitmeta-1.7/editor/directives/dialCode/dialCodeDirective.js
@@ -150,6 +150,7 @@ angular.module('editorApp', ['ngDialog', 'oc.lazyLoad', 'Scope.safeApply']).dire
 
         $scope.updateDialCode = function (event, data) {
             $scope.dialcodes = "";
+            $scope.errorMessage = "";
             if ($scope.contentMeta.mimeType == 'application/vnd.ekstep.content-collection') {
                 var node = org.ekstep.services.collectionService.getActiveNode();
                 if(node.data.metadata.dialcodes){


### PR DESCRIPTION
**Ref:** https://project-sunbird.atlassian.net/browse/SB-12290

**Description:**
The error message "Please enter valid QR code" is displayed throughout even if the QR Required field is set to "No" for different units.