### PR TITLE
Issue #SB-12558 fix: Resource: Contour integration symbol is not displayed in add math text.

### DIFF
--- a/org.ekstep.mathtext-1.0/editor/mathtext.js
+++ b/org.ekstep.mathtext-1.0/editor/mathtext.js
@@ -422,7 +422,7 @@ angular.module('org.ekstep.mathtext', [])
           latex: "\\int _{ }^{ }"
         },
         {
-          latex: "\oint"
+          latex: "\\oint"
         }
       ],
       supsub: [


### PR DESCRIPTION
[JIRA LINK](https://project-sunbird.atlassian.net/browse/SB-12558)