### PR TITLE
Issue #SB-12511 fix: On removing dial codes from published textbook and sending it for review,Reviewer is still able to view the old dial code attached to the text book

### DIFF
--- a/org.ekstep.contenteditorfunctions-1.2/editor/plugin.js
+++ b/org.ekstep.contenteditorfunctions-1.2/editor/plugin.js
@@ -525,7 +525,7 @@ org.ekstep.contenteditor.basePlugin.extend({
         });
         var dialcodesUpdated = false;
         ecEditor._.forIn(nodesModified, function(node) {
-            if(node.metadata.dialcodes && !dialcodesUpdated){
+            if(!_.isUndefined(node.metadata.dialcodes) && !dialcodesUpdated){
                 dialcodesUpdated = true;
             }else{
                 var dialObj =  _.find(mapArr,function(Obj){
@@ -541,7 +541,9 @@ org.ekstep.contenteditor.basePlugin.extend({
         }
     },
     dialcodeLink: function(dialcodeMap) {
-        var dialcodeMapObj = _.find(dialcodeMap, 'dialcode');
+        var dialcodeMapObj = _.find(dialcodeMap, function(o){
+		    return o.dialcode != undefined
+        });
         if(!_.isEmpty(dialcodeMap)){
             var request = {
                 "request": {

--- a/org.ekstep.contenteditorfunctions-1.2/test/editor/plugin.spec.js
+++ b/org.ekstep.contenteditorfunctions-1.2/test/editor/plugin.spec.js
@@ -40,6 +40,16 @@ describe("Ekstep contenteditorfunction Plugin:", function() {
             expect(pluginInstance.dialcodeLink).toHaveBeenCalled();
             done();
         });
+
+        it('Should invoke dialcodelink method to save dialcode and dialcode is empty string', function (done) {
+            var dialcodeMap = "";
+            org.ekstep.services.stateService.state = {'invaliddialCodeMap':'invalid'};
+            spyOn(pluginInstance, "dialcodeLink").and.callThrough();
+            pluginInstance.dialcodeLink(dialcodeMap);
+            expect(pluginInstance.dialcodeLink).not.toBeUndefined();
+            expect(pluginInstance.dialcodeLink).toHaveBeenCalled();
+            done();
+        });
     
     });
 })

--- a/org.ekstep.unitmeta-1.7/editor/directives/dialCode/dialCodeDirective.js
+++ b/org.ekstep.unitmeta-1.7/editor/directives/dialCode/dialCodeDirective.js
@@ -114,7 +114,7 @@ angular.module('editorApp', ['ngDialog', 'oc.lazyLoad', 'Scope.safeApply']).dire
                     stateService.create('dialCodeMap');
                 }
                 stateService.setState('dialCodeMap', currentNode.id, "");
-                currentNode.metadata.dialcodes = undefined;
+                currentNode.metadata.dialcodes = "";
             }
             ecEditor.dispatchEvent('org.ekstep.collectioneditor:node:modified');
         }


### PR DESCRIPTION
Issue #SB-12511 fix: On removing dial codes from published textbook and sending it for review,Reviewer is still able to view the old dial code attached to the text book

Scenaios:- 

- [x]  After removing “QR code“ - if the user clicks on save button, content should save without QR code(Unilink QR code) and after refreshing QR code should not see in metaform.

- [x] Without removing “QR code“ - if the user selects QR CODE REQUIRED: “No“, content should save with QR code with QR CODE REQUIRED: “No“ and after refreshing QR code property should be disabled.

- [x]  After removing “QR code“ in a draft copy of live textbook - if the user clicks on send for review button, Please fill in missing QR codes or remove QR code were not required` error message should show. 

- [x]  After removing “QR code“ in draft copy of live textbook and selects QR CODE REQUIRED: “No“ - if user clicks on send for review button, the textbook should send for review without QR code(Unilink QR code)  and Book reviewer should not be able to see the removed dial codes.
