### PR TITLE
#SB-13364 fix: delete assessmentId while creating new question

### DIFF
--- a/org.ekstep.question-1.0/editor/question-ctrl.js
+++ b/org.ekstep.question-1.0/editor/question-ctrl.js
@@ -118,7 +118,11 @@ angular.module('org.ekstep.question', ['org.ekstep.metadataform'])
 		$scope.pluginVer = obj.ver;
 		$scope.templateId = obj.editor.template;
 		var templatePath = ecEditor.resolvePluginResource(obj.pluginID, obj.ver, obj.editor.templateURL);
-		$scope.questionUnitTemplateURL = templatePath + '?BUILDNUMBER';
+    $scope.questionUnitTemplateURL = templatePath + '?BUILDNUMBER';
+    
+    if($scope.assessmentId){
+      delete $scope.assessmentId;
+    }
 	}
 	$scope.showMetaform = function () {
 		$scope.refreshPreview = false;


### PR DESCRIPTION
Issue: #SB-13364 
"$scope.assessmentId" value is retaining while creating new question after edit mode.
Ideally it should not, So, deleting if present.