### PR TITLE
Issue #SB-12073 fix: question metadata max_score always should be number

### DIFF
--- a/org.ekstep.question-1.0/editor/question-ctrl.js
+++ b/org.ekstep.question-1.0/editor/question-ctrl.js
@@ -279,7 +279,7 @@ angular.module('org.ekstep.question', ['org.ekstep.metadataform'])
         var metadataObj = $scope.questionMetaData;    
         metadataObj.category = $scope.category;
         // TODO: questionCount should be sent from unit template controllers. Currently it is hardcoded to 1.
-        data.config = { "metadata": metadataObj, "max_time": 0, "max_score": $scope.questionData.max_score, "partial_scoring": $scope.questionData.isPartialScore, "layout": $scope.questionData.templateType, "isShuffleOption" : $scope.questionData.isShuffleOption, "questionCount": 1, "evalUnordered": $scope.questionData.evalUnordered};
+        data.config = { "metadata": metadataObj, "max_time": 0, "max_score": Number($scope.questionData.max_score), "partial_scoring": $scope.questionData.isPartialScore, "layout": $scope.questionData.templateType, "isShuffleOption" : $scope.questionData.isShuffleOption, "questionCount": 1, "evalUnordered": $scope.questionData.evalUnordered};
         data.media = $scope.questionCreationFormData.media;
         questionFormData.data = data;
         var metadata = {


### PR DESCRIPTION
[JIRA ISSUE](https://project-sunbird.atlassian.net/browse/SB-12073)