### PR TITLE
Issue #SB-14375 fix: Zoom icon in answer options is displayed big for…

### DIFF
--- a/org.ekstep.questionunit.mcq-1.3/renderer/styles/style.css
+++ b/org.ekstep.questionunit.mcq-1.3/renderer/styles/style.css
@@ -1532,6 +1532,7 @@ text-align: center;
     position: absolute;
     bottom: -2%;
     right: 0%;
-    width: 40%;
+    width: 50%;
+    max-width: 35px;
     cursor: pointer;
 }


### PR DESCRIPTION
… 3rd layout in consumption compared to the zoom icon present in other layout options