### PR TITLE
Issue #SB-14379 fix: MCQ: Question Line spacing in consumption for 1st and 2nd layout is not similar to other mcq layouts

### DIFF
--- a/org.ekstep.questionunit.mcq-1.3/renderer/template/mcq-layouts.js
+++ b/org.ekstep.questionunit.mcq-1.3/renderer/template/mcq-layouts.js
@@ -173,7 +173,7 @@ MCQController.grid.getOptionsTemplate = function (options) {
 MCQController.grid.getTemplate = function (question) {
     var wrapperEnd = '</div>';
     var template =
-        '<div class="mcq-question-container-grid plugin-content-container">\
+        '<div class="mcq-question-container-grid plugin-content-container mcq-content-container">\
     <div class="mcq-grid-question-container question-content-container">' +
         org.ekstep.questionunit.questionComponent.generateQuestionComponent() +
         wrapperEnd +


### PR DESCRIPTION
Issue #SB-14379 fix: MCQ: Question Line spacing in consumption for 1st and 2nd layout is not similar to other mcq layouts