### PR TITLE
Issue #SB-17701 fix: Self assess : Wrong count in summary plugin 

### DIFF
--- a/org.ekstep.questionset-1.0/renderer/plugin.js
+++ b/org.ekstep.questionset-1.0/renderer/plugin.js
@@ -200,7 +200,7 @@ org.ekstep.questionsetRenderer = IteratorPlugin.extend({ // eslint-disable-line 
         }else{
           if(!pluginInstance._question.overrideFeedbackPopUp){
             QSTelemetryLogger.logEvent(QSTelemetryLogger.EVENT_TYPES.ASSESSEND, result);
-            instance._displayedPopup = true;
+            // instance._displayedPopup = true;
           }
           if(instance._currentQuestionState && _.isEqual(instance._currentQuestionState.val, result.state.val)){
             instance.renderNextQuestion();


### PR DESCRIPTION
Self assess Total number of questions displayed incorrect, for any number of questions added, it shows only 3 questions in the summary slide