### PR TITLE
Issue #SB-19291 fix: Question field is Blank when text and equation is added for MCQ and MTF type questions in the content editor preview

### DIFF
--- a/org.ekstep.questionunit-1.1/editor/plugin.js
+++ b/org.ekstep.questionunit-1.1/editor/plugin.js
@@ -113,10 +113,8 @@ org.ekstep.contenteditor.questionUnitPlugin = org.ekstep.contenteditor.basePlugi
             data.text = $(element).prop('outerHTML');
           }
           return data.text;
-      }else if(index == -1){
-        return data.text.replace(/<p>/g, "<p style='font-size:1.285em;'>");
       }else{
-        return data.text;
+        return data.text.replace(/<p>/g, "<p style='font-size:1.285em;'>");
       }
   }
 });

--- a/org.ekstep.questionunit-1.1/editor/plugin.js
+++ b/org.ekstep.questionunit-1.1/editor/plugin.js
@@ -115,6 +115,8 @@ org.ekstep.contenteditor.questionUnitPlugin = org.ekstep.contenteditor.basePlugi
           return data.text;
       }else if(index == -1){
         return data.text.replace(/<p>/g, "<p style='font-size:1.285em;'>");
+      }else{
+        return data.text;
       }
   }
 });


### PR DESCRIPTION
Issue #SB-19291 fix: Question field is Blank when text and equation is added for MCQ and MTF type questions in the content editor preview