### PR TITLE
Issue #SB-19291 fix: Question field is Blank when text and equation is added for MCQ and MTF type questions in the content editor preview

### DIFF
--- a/org.ekstep.questionunit-1.2/editor/plugin.js
+++ b/org.ekstep.questionunit-1.2/editor/plugin.js
@@ -113,7 +113,7 @@ org.ekstep.contenteditor.questionUnitPlugin = org.ekstep.contenteditor.basePlugi
             data.text = $(element).prop('outerHTML');
           }
           return data.text;
-      }else if(index == -1){
+      }else{
         return data.text.replace(/<p>/g, "<p style='font-size:1.285em;'>");
       }
   }


### PR DESCRIPTION
Issue #SB-19291 fix: Question field is Blank when text and equation is added for MCQ and MTF type questions in the content editor preview