### PR TITLE
Issue #SB-19606 fix: Summary page screen shows previously played content is name while creating a book

### DIFF
--- a/org.ekstep.collectioneditor-1.6/editor/collectionEditorApp.js
+++ b/org.ekstep.collectioneditor-1.6/editor/collectionEditorApp.js
@@ -159,12 +159,8 @@ angular.module('org.ekstep.collectioneditor', ["Scope.safeApply", "ui.sortable"]
         }
         var previewIframe = document.getElementById('previewContentIframe');
         previewIframe.style.display = "block";
-        if (!previewIframe.src) {
-            previewIframe.src = (ecEditor.getConfig('previewURL') || '/content/preview/preview.html') + '?webview=true';
-            previewIframe.onload = function() {
-                initializeRenderer();
-            }
-        } else {
+        previewIframe.src = (ecEditor.getConfig('previewURL') || '/content/preview/preview.html') + '?webview=true';
+        previewIframe.onload = function() {
             initializeRenderer();
         }
     }


### PR DESCRIPTION
Issue #SB-19606 fix: Summary page screen shows previously played content is name while creating a book