### PR TITLE
Issue #SB-24150 fix: Portal: When the user taps on the review button at the summary page of an assessment, PAYLOAD TOO LARGE error is displayed

### DIFF
--- a/org.ekstep.summary-1.0/renderer/plugin.js
+++ b/org.ekstep.summary-1.0/renderer/plugin.js
@@ -72,6 +72,14 @@ org.ekstep.summaryRenderer = Plugin.extend({ // eslint-disable-line no-undef
       stageId: Renderer.theme._currentStage,
       subtype: ''
     });
+    if (!window.location.origin) {
+      origin = window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '');
+    } else {
+      origin = window.location.origin
+    }
+
+    window.postMessage('renderer:question:reviewAssessment',origin);
+    
     const allStagesList = EkstepRendererAPI.getAllStages();
     const firstContentStage = EkstepRendererAPI.getContentData();
 


### PR DESCRIPTION
Issue #SB-24150 fix: Portal: When the user taps on the review button at the summary page of an assessment, PAYLOAD TOO LARGE error is displayed