### PR TITLE
chore: add Dependabot and dependency-submission workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  # Root package.json — karma/jasmine test tooling for the plugin collection
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"        # 30 min after dependency-submission workflow (03:00 UTC)
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      karma-testing:
+        patterns:
+          - "karma*"
+          - "jasmine*"
+
+  # Keep GitHub Actions workflow action versions updated
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"
+      timezone: "UTC"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,32 @@
+name: Dependency Submission
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'          # 03:00 UTC every Monday — runs before Dependabot (03:30)
+  push:
+    branches: [master]
+    paths:
+      - 'package.json'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'package.json'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  submit-npm-root:
+    name: Submit npm (root)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      # No lock file at root — generate one without installing node_modules
+      - run: npm install --package-lock-only
+      - uses: advanced-security/npm-dependency-submission-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
                                                                                                                                                                                      
  - Enables Dependabot to automatically open weekly PRs for npm and GitHub Actions dependency updates, keeping the plugin collection's test tooling and CI actions current without    
  manual tracking.                                                                                                                                                                    
  - Adds a dependency-submission workflow that populates the GitHub Dependency Graph on each push to `master` (and on a weekly schedule), enabling security vulnerability alerts      
  (Dependabot alerts) for the lockfile-less root package.                                                                                                                             
  ## Changes
                                                                                                                                                                                      
  - Add `.github/dependabot.yml` — configures weekly npm updates (grouped for `karma*`/`jasmine*`) and weekly GitHub Actions updates, both scheduled Monday 03:30 UTC
  - Add `.github/workflows/dependency-submission.yml` — generates a lock file (`npm install --package-lock-only`) and submits it to the Dependency Graph via                          
  `advanced-security/npm-dependency-submission-action@v1`; runs on schedule (Monday 03:00 UTC), push to `master` on `package.json` changes, and PRs         
                                                                                                                                                                                      
  ## How to Test                                         
                                                                                                                                                                                      
  1. Merge to `master` and verify the **Dependency Submission** workflow runs successfully under **Actions**.
  2. Navigate to **Insights → Dependency graph** on GitHub and confirm npm dependencies from the root `package.json` are listed.                                                      
  3. On the following Monday, check that Dependabot PRs are opened (or check **Security → Dependabot** for scheduled scan status).
                                                                                                                                                                                      
  ## Checklist                                                                                                                                                                        
                                                                                                                                                                                      
  - [ ] Tests added or updated                                                                                                                                                        
  - [ ] Documentation updated (if public API or behavior changed)
  - [ ] No breaking changes — or breaking changes noted with `!` in title and explained in Summary
  - [ ] Reviewed my own diff before requesting review